### PR TITLE
Correção para o atributo BrokerType serializar o nome do broker

### DIFF
--- a/RabbitCL/rcl.background/IO/ConfigurationIO.cs
+++ b/RabbitCL/rcl.background/IO/ConfigurationIO.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using rcl.Entities;
 using System.IO;
 using System.Reflection;
@@ -21,7 +22,10 @@ namespace rcl.IO
             if (File.Exists(_filePath))
                 File.Delete(_filePath);
 
-            File.WriteAllText(_filePath, JsonConvert.SerializeObject(configuration));
+            JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings();
+            jsonSerializerSettings.Converters.Add(new StringEnumConverter());
+
+            File.WriteAllText(_filePath, JsonConvert.SerializeObject(configuration, jsonSerializerSettings));
         }
 
         public Configuration Get()


### PR DESCRIPTION
Correção para o atributo BrokerType serializar o nome do broker e nã o valor do enum no json de configuração.